### PR TITLE
only make commands in `rust_analyzer` buffers

### DIFF
--- a/lua/ferris.lua
+++ b/lua/ferris.lua
@@ -9,7 +9,12 @@ function M.setup(opts)
             group = vim.api.nvim_create_augroup("ferris_commands", { clear = true }),
             desc = "Add Ferris user commands to rust_analyzer buffers",
             callback = function(args)
-                if vim.lsp.get_client_by_id(args.data.client_id).name == "rust_analyzer" then
+                local lsp = require("ferris.private.ra_lsp")
+
+                local client = vim.lsp.get_client_by_id(args.data.client_id)
+                ---@cast client -nil
+
+                if lsp.client_is_ra(client) then
                     M.create_commands(args.buf)
                 end
             end,
@@ -17,7 +22,7 @@ function M.setup(opts)
     end
 end
 
---- Create user commands for the methods provided by Ferris
+---Create user commands for the methods provided by Ferris
 ---@param bufnr? integer Optional buffer number to only add the commands to a given buffer. Default behavior is to create global user commands
 function M.create_commands(bufnr)
     local function cmd(name, module, opts)

--- a/lua/ferris.lua
+++ b/lua/ferris.lua
@@ -5,23 +5,41 @@ function M.setup(opts)
     config.update(opts)
 
     if config.opts.create_commands then
-        local function cmd(name, module, opts)
+        vim.api.nvim_create_autocmd("LspAttach", {
+            group = vim.api.nvim_create_augroup("ferris_commands", { clear = true }),
+            desc = "Add Ferris user commands to rust_analyzer buffers",
+            callback = function(args)
+                if vim.lsp.get_client_by_id(args.data.client_id).name == "rust_analyzer" then
+                    M.create_commands(args.buf)
+                end
+            end,
+        })
+    end
+end
+
+--- Create user commands for the methods provided by Ferris
+---@param bufnr? integer Optional buffer number to only add the commands to a given buffer. Default behavior is to create global user commands
+function M.create_commands(bufnr)
+    local function cmd(name, module, opts)
+        if bufnr then
+            vim.api.nvim_buf_create_user_command(bufnr, name, require(module), opts or {})
+        else
             vim.api.nvim_create_user_command(name, require(module), opts or {})
         end
-
-        cmd("FerrisExpandMacro", "ferris.methods.expand_macro")
-        cmd("FerrisJoinLines", "ferris.methods.join_lines", { range = true })
-        cmd("FerrisViewHIR", "ferris.methods.view_hir")
-        cmd("FerrisViewMIR", "ferris.methods.view_mir")
-        cmd("FerrisViewMemoryLayout", "ferris.methods.view_memory_layout")
-        cmd("FerrisViewSyntaxTree", "ferris.methods.view_syntax_tree", { range = true })
-        cmd("FerrisViewItemTree", "ferris.methods.view_item_tree")
-        cmd("FerrisOpenCargoToml", "ferris.methods.open_cargo_toml")
-        cmd("FerrisOpenParentModule", "ferris.methods.open_parent_module")
-        cmd("FerrisOpenDocumentation", "ferris.methods.open_documentation")
-        cmd("FerrisReloadWorkspace", "ferris.methods.reload_workspace")
-        cmd("FerrisRebuildMacros", "ferris.methods.rebuild_macros")
     end
+
+    cmd("FerrisExpandMacro", "ferris.methods.expand_macro")
+    cmd("FerrisJoinLines", "ferris.methods.join_lines", { range = true })
+    cmd("FerrisViewHIR", "ferris.methods.view_hir")
+    cmd("FerrisViewMIR", "ferris.methods.view_mir")
+    cmd("FerrisViewMemoryLayout", "ferris.methods.view_memory_layout")
+    cmd("FerrisViewSyntaxTree", "ferris.methods.view_syntax_tree", { range = true })
+    cmd("FerrisViewItemTree", "ferris.methods.view_item_tree")
+    cmd("FerrisOpenCargoToml", "ferris.methods.open_cargo_toml")
+    cmd("FerrisOpenParentModule", "ferris.methods.open_parent_module")
+    cmd("FerrisOpenDocumentation", "ferris.methods.open_documentation")
+    cmd("FerrisReloadWorkspace", "ferris.methods.reload_workspace")
+    cmd("FerrisRebuildMacros", "ferris.methods.rebuild_macros")
 end
 
 return M


### PR DESCRIPTION
This also exposes the command creation just in case people want to set up lazy loading of the plugin easily. Here is an example of lazy loading the plugin with Lazy.nvim with these changes:

```lua
{
  "mehalter/ferris.nvim", -- this would change once this is merged
  lazy = true,
  init = function()
    vim.api.nvim_create_autocmd("LspAttach", {
      callback = function(args)
        if vim.lsp.get_client_by_id(args.data.client_id).name == "rust_analyzer" then
          require("ferris").create_commands(args.buf)
        end
      end,
    })
  end,
  opts = { create_commands = false },
}
```