### PR TITLE
fix client detection when using rustaceanvim

### DIFF
--- a/lua/ferris/private/ra_lsp.lua
+++ b/lua/ferris/private/ra_lsp.lua
@@ -59,7 +59,7 @@ end
 ---@return boolean
 function M.client_is_ra(client)
     -- test by name
-    if client.name == "rust_analyzer" then
+    if client.name == "rust_analyzer" or client.name == "rust-analyzer" then
         return true
     end
 


### PR DESCRIPTION
When using [rustaceanvim](https://github.com/mrcjkb/rustaceanvim) `client.name` returns `rust-analyzer` instead of `rust_analyzer`. This patch changes the `client_is_ra` function to allow both variants.