### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _note: this plugin has only been tested with neovim 0.9+_
 with lazy.nvim:
 ```lua
 {
-    'vxpm/ferris.nvim'
+    'vxpm/ferris.nvim',
     opts = {
         -- your options here
     }


### PR DESCRIPTION
Added missing comma in `lazy.nvim` installation snippet.