### PR TITLE
Explicit buffer number for join_lines

### DIFF
--- a/lua/ferris/methods/join_lines.lua
+++ b/lua/ferris/methods/join_lines.lua
@@ -5,7 +5,8 @@ local error = require("ferris.private.error")
 local function join_lines(r)
     if not error.ensure_ra() then return end
 
-    local params = vim.lsp.util.make_given_range_params(nil, nil, 0, lsp.offset_encoding());
+    local buf = vim.api.nvim_get_current_buf()
+    local params = vim.lsp.util.make_given_range_params(nil, nil, buf, lsp.offset_encoding());
     params.ranges = { params.range }
     params.range = nil
 
@@ -21,7 +22,7 @@ local function join_lines(r)
             return
         end
 
-        vim.lsp.util.apply_text_edits(response.result, 0, lsp.offset_encoding())
+        vim.lsp.util.apply_text_edits(response.result, buf, lsp.offset_encoding())
     end)
 end
 


### PR DESCRIPTION
Fixes:
```
Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/lsp/util.lua:301: Explicit buffer number is required                                                                                                     
stack traceback:                                                                                                                                                                                                                              
        [C]: in function 'assert'                                                                                                                                                                                                             
        /usr/share/nvim/runtime/lua/vim/lsp/util.lua:301: in function 'apply_text_edits'                                                                                                                                                      
        ...onfig/nvim/ferris.nvim/lua/ferris/methods/join_lines.lua:26: in function 'handler'                                                                                                                                                 
        ...y/.config/nvim/ferris.nvim/lua/ferris/private/ra_lsp.lua:26: in function 'handler'                                                                                                                                                 
        /usr/share/nvim/runtime/lua/vim/lsp.lua:1218: in function 'handler'                                                                                                                                                                   
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:679: in function ''                                                                                                                                                                    
        vim/_editor.lua: in function <vim/_editor.lua:0>        
```
