### PR TITLE
Replace deprecated `client.request_sync` with `client:request_sync`

### DIFF
--- a/lua/ferris/private/ra_lsp.lua
+++ b/lua/ferris/private/ra_lsp.lua
@@ -66,7 +66,7 @@ function M.client_is_ra(client)
     -- test by a rust-analyzer specific request
     -- WARN: lua_ls says this is private - but neovim api does not say anything
     -- about it being so..
-    local response = client.request_sync("rust-analyzer/analyzerStatus", {}, 100, 0)
+    local response = client:request_sync("rust-analyzer/analyzerStatus", {}, 100, 0)
     return response ~= nil and response.result ~= nil
 end
 


### PR DESCRIPTION
Fixes deprecation warning in Neovim 0.11+ by replacing LSP client method calls with new colon syntax.

Neovim 0.11+ displays the warning
```
client.request is deprecated. Feature will be removed in Nvim 0.13
ADVICE: use client:request instead.
```

This fix should cause no breaking changes and is just a syntax update.